### PR TITLE
🧹 fix typo in comment: 'Mobility in soilMobility in soil'

### DIFF
--- a/SDSComXSL.xsl
+++ b/SDSComXSL.xsl
@@ -1203,7 +1203,7 @@
                     </xsl:if>
                 </li>
 
-                <!-- Mobility in soilMobility in soil -->
+                <!-- Mobility in soil -->
                 <li>
                     <h3>
                         <xsl:value-of select="$Section12.4"/>


### PR DESCRIPTION
### 🎯 **What:**
Fixed a typo in a comment within `SDSComXSL.xsl` where "Mobility in soil" was accidentally repeated as "Mobility in soilMobility in soil".

### 💡 **Why:**
This improves the readability and maintainability of the XSL template by ensuring comments are accurate and professional.

### ✅ **Verification:**
- Verified the fix using `grep` to ensure the duplicate phrase was removed.
- Confirmed the change is within a comment and thus has no impact on functionality.
- Attempted to run `npm run test`, but dependencies were missing in the environment and `npm install` timed out; however, since this is a comment-only change, it is safe.

### ✨ **Result:**
The comment at line 1206 of `SDSComXSL.xsl` is now correctly formatted as `<!-- Mobility in soil -->`.

---
*PR created automatically by Jules for task [2613348891841498546](https://jules.google.com/task/2613348891841498546) started by @SmolSoftBoi*

## Summary by Sourcery

Chores:
- Correct a repeated "Mobility in soil" phrase in an XSL stylesheet comment to improve readability.